### PR TITLE
Fix Adobe reader check for IE 11

### DIFF
--- a/pdfobject.js
+++ b/pdfobject.js
@@ -53,7 +53,7 @@ var PDFObject = function (obj){
 
         var axObj = null;
 
-        if (window.ActiveXObject) {
+        if (window.ActiveXObject !== undefined) {
 
             axObj = createAXO("AcroPDF.PDF");
 


### PR DESCRIPTION
Check for undefined, instead of truthy check on window.ActiveXObject

Fixes https://github.com/pipwerks/PDFObject/issues/36