### PR TITLE
Support iPad

### DIFF
--- a/pdfobject.js
+++ b/pdfobject.js
@@ -15,8 +15,8 @@ var PDFObject = function (obj){
     var pdfobjectversion = "1.2",
         //Set reasonable defaults
         id = obj.id || false,
-        width = obj.width || "100%",
-        height = obj.height || "100%",
+        width = obj.width,
+        height = obj.height,
         pdfOpenParams = obj.pdfOpenParams,
         url,
         pluginTypeFound,
@@ -98,12 +98,16 @@ var PDFObject = function (obj){
     };
 
 
-    //Determines what kind of PDF support is available: Adobe or generic
+    //Determines what kind of PDF support is available: iPad, Adobe or generic
     pluginFound = function (){
 
         var type = null;
 
-        if(hasReader() || hasReaderActiveX()){
+        if(navigator.userAgent.match(/iPad/i) != null) {
+
+            type = "iPad";
+
+        } else if(hasReader() || hasReaderActiveX()){
 
             type = "Adobe";
 
@@ -219,8 +223,19 @@ var PDFObject = function (obj){
 
             targetNode = document.body;
             setCssForFullWindowPdf();
-            width = "100%";
-            height = "100%";
+            if(pluginTypeFound === 'iPad') {
+
+                // Ideally we want the width and height to be the same as the rendered pdf document.
+                // Use large values as default to make sure most pdfs is visible
+                width = width || '1000';
+                height = height || '4000';
+
+            } else {
+
+                width = "100%";
+                height = "100%";
+
+            }
 
         }
 


### PR DESCRIPTION
Check if device is iPad. If so, render pdf as usual. pluginFound now returns "iPad".

Also remove default initialisation of width and height. If they are not set, they are either way initialised on line 225,226. If device is iPad, and user has not set width and height, use "huge" values. iPad flattens the rendering, i.e. the pdf content is not "scrollable" so everything has to be visible.