### PR TITLE
Add `supportRedirect` option for Safari

### DIFF
--- a/pdfobject.js
+++ b/pdfobject.js
@@ -223,7 +223,7 @@
         }
 
         targetNode.className += " pdfobject-container";
-        targetNode.innerHTML = "<iframe sandbox='' " + id + " class='pdfobject' src='" + url + pdfOpenFragment + "' type='application/pdf' style='border: none; " + style + "'/>";
+        targetNode.innerHTML = "<iframe " + id + " class='pdfobject' src='" + url + pdfOpenFragment + "' type='application/pdf' style='border: none; " + style + "'/>";
 
         return targetNode.getElementsByTagName("iframe")[0];
 

--- a/pdfobject.js
+++ b/pdfobject.js
@@ -61,7 +61,8 @@
         embed,
         getTargetElement,
         generatePDFJSiframe,
-        generateEmbedElement;
+        generateEmbedElement,
+        generateIframeElement;
 
 
     /* ----------------------------------------------------
@@ -86,6 +87,11 @@
     //Constructed as a method (not a prop) to avoid unneccesarry overhead -- will only be evaluated if needed
     isIE = function (){ return !!(window.ActiveXObject || "ActiveXObject" in window); };
 
+    // Detect desktop Safari
+    // Relying on the Apple pushNotifications api, implemented in 10.9
+    // See https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html
+    isSafariOsx = 'safari' in window;
+
     //If either ActiveX support for "AcroPDF.PDF" or "PDF.PdfCtrl" are found, return true
     //Constructed as a method (not a prop) to avoid unneccesarry overhead -- will only be evaluated if needed
     supportsPdfActiveX = function (){ return !!(createAXO("AcroPDF.PDF") || createAXO("PDF.PdfCtrl")); };
@@ -97,7 +103,7 @@
         //Therefore if iOS, we shall assume that PDF support is not available
         !isIOS && (
             //Modern versions of Firefox come bundled with PDFJS
-            isFirefoxWithPDFJS || 
+            isFirefoxWithPDFJS ||
             //Browsers that still support the original MIME type check
             supportsPdfMimeType || (
                 //Pity the poor souls still using IE
@@ -206,6 +212,23 @@
 
     };
 
+    generateIframeElement = function (targetNode, targetSelector, url, pdfOpenFragment, width, height, id){
+
+        var style = "";
+
+        if(targetSelector && targetSelector !== document.body){
+            style = "width: " + width + "; height: " + height + ";";
+        } else {
+            style = "position: absolute; top: 0; right: 0; bottom: 0; left: 0; width: 100%; height: 100%;";
+        }
+
+        targetNode.className += " pdfobject-container";
+        targetNode.innerHTML = "<iframe sandbox='' " + id + " class='pdfobject' src='" + url + pdfOpenFragment + "' type='application/pdf' style='border: none; " + style + "'/>";
+
+        return targetNode.getElementsByTagName("iframe")[0];
+
+    };
+
     embed = function(url, targetSelector, options){
 
         //Ensure URL is available. If not, exit now.
@@ -226,6 +249,7 @@
             height = (options.height) ? options.height : "100%",
             assumptionMode = (typeof options.assumptionMode === "boolean") ? options.assumptionMode : true,
             forcePDFJS = (typeof options.forcePDFJS === "boolean") ? options.forcePDFJS : false,
+            supportRedirect = (typeof options.supportRedirect === "boolean") ? options.supportRedirect : false,
             PDFJS_URL = (options.PDFJS_URL) ? options.PDFJS_URL : false,
             targetNode = getTargetElement(targetSelector),
             fallbackHTML = "",
@@ -253,6 +277,11 @@
 
         //If traditional support is provided, or if this is a modern browser and not iOS (see comment for supportsPDFs declaration)
         } else if(supportsPDFs || (assumptionMode && isModernBrowser && !isIOS)){
+
+            // Safari will not honour redirect responses on embed src.
+            if (supportRedirect && isSafariOsx) {
+                return generateIframeElement(targetNode, targetSelector, url, pdfOpenFragment, width, height, id);
+            }
 
             return generateEmbedElement(targetNode, targetSelector, url, pdfOpenFragment, width, height, id);
 

--- a/pdfobject.js
+++ b/pdfobject.js
@@ -88,9 +88,11 @@
     isIE = function (){ return !!(window.ActiveXObject || "ActiveXObject" in window); };
 
     // Detect desktop Safari
-    // Relying on the Apple pushNotifications api, implemented in 10.9
-    // See https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html
-    isSafariOsx = 'safari' in window;
+    isSafariOsx = (
+        !isIOS &&
+        navigator.vendor && navigator.vendor.indexOf('Apple') !== -1 &&
+        navigator.userAgent && navigator.userAgent.indexOf('Safari') !== -1
+    );
 
     //If either ActiveX support for "AcroPDF.PDF" or "PDF.PdfCtrl" are found, return true
     //Constructed as a method (not a prop) to avoid unneccesarry overhead -- will only be evaluated if needed


### PR DESCRIPTION
This replaces https://github.com/pipwerks/PDFObject/pull/197 which addressed multiple issues.

Solves issue https://github.com/pipwerks/PDFObject/issues/196 where Safari OSX does not work with pdf urls that return a 302/301 redirect. Use of 302 redirects is increasingly common as content files are stored in services such as S3 but presented at urls within an app domain.

This workaround outputs an iframe if the browser is Safari desktop and the `supportRedirect` option is true. There are no behaviour changes if the option is not set. The `isSafariOsx` flag is new and does not alter existing `isIOS`.

Example use:
```
PDFObject.embed("myfile.pdf", "#my-container", { supportRedirect: true }); 
```

Note: This PR does not update the min.js file. If https://github.com/pipwerks/PDFObject/pull/208 is merged first I can rebase this branch and build the minified file.