### PR TITLE
Handling invalid firefox user agent

### DIFF
--- a/pdfobject.js
+++ b/pdfobject.js
@@ -76,7 +76,7 @@
                             /Safari/.test(ua) );
     
     //Firefox started shipping PDF.js in Firefox 19. If this is Firefox 19 or greater, assume PDF.js is available
-    let isFirefoxWithPDFJS = (!isMobileDevice && /irefox/.test(ua)) ? (parseInt(ua.split("rv:")[1].split(".")[0], 10) > 18) : false;
+    let isFirefoxWithPDFJS = (!isMobileDevice && /irefox/.test(ua) && ua.split("rv:").length > 1) ? (parseInt(ua.split("rv:")[1].split(".")[0], 10) > 18) : false;
 
 
     /* ----------------------------------------------------


### PR DESCRIPTION
Preventing the following user agent (comes from ELO device) to cause a crash:
`Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.75.14 (KHTML, like Gecko) Chrome/51.0.2704.84 Version/7.0.3 Safari/7046A194A Gecko/20100101 Firefox/47.0.1`