### PR TITLE
PDFJS_URL parameters fix

### DIFF
--- a/pdfobject.js
+++ b/pdfobject.js
@@ -189,7 +189,13 @@
         //Ensure target element is empty first
         emptyNodeContents(targetNode);
 
-        let fullURL = PDFJS_URL + "?file=" + encodeURIComponent(url) + pdfOpenFragment;
+        if (PDFJS_URL.indexOf("?") !== -1) {
+            PDFJS_URL += '&';
+        } else {
+            PDFJS_URL += '?';
+        }
+
+        let fullURL = PDFJS_URL + "file=" + encodeURIComponent(url) + pdfOpenFragment;
         let div = document.createElement("div");
         let iframe = document.createElement("iframe");
         


### PR DESCRIPTION
If `PDFJS_URL` contains a question mark already, building `fullURL` (including the pdf file as parameter) may fail.