### PR TITLE
Add some more badges to README and move them below title

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # PDFObject
 
+[![npm](https://img.shields.io/npm/v/pdfobject.svg?style=flat)](https://www.npmjs.org/package/pdfobject) [![CDNJS](https://img.shields.io/cdnjs/v/pdfobject.svg)](https://cdnjs.com/libraries/pdfobject/) [![](https://img.shields.io/npm/dm/pdfobject.svg)](https://www.npmjs.org/package/pdfobject) [![](https://img.shields.io/bundlephobia/minzip/pdfobject.svg)](https://bundlephobia.com/package/pdfobject) [![](https://packagephobia.com/badge?p=pdfobject)](https://packagephobia.com/result?p=pdfobject)
+
 A lightweight JavaScript utility for dynamically embedding PDFs in HTML documents.
 
 Examples and documentation can be found at https://pdfobject.com.
@@ -11,8 +13,6 @@ Copyright (c) 2008-2024 Philip Hutchison
 MIT-style license: http://pipwerks.mit-license.org/
 
 -----
-
-[![npm](https://img.shields.io/npm/v/pdfobject.svg?style=flat)](https://www.npmjs.org/package/pdfobject) [![CDNJS](https://img.shields.io/cdnjs/v/pdfobject.svg)](https://cdnjs.com/libraries/pdfobject/)
 
 ## Changelog
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # PDFObject
 
-[![npm](https://img.shields.io/npm/v/pdfobject.svg?style=flat)](https://www.npmjs.org/package/pdfobject) [![CDNJS](https://img.shields.io/cdnjs/v/pdfobject.svg)](https://cdnjs.com/libraries/pdfobject/) [![](https://img.shields.io/npm/dm/pdfobject.svg)](https://www.npmjs.org/package/pdfobject) [![](https://img.shields.io/bundlephobia/minzip/pdfobject.svg)](https://bundlephobia.com/package/pdfobject) [![](https://packagephobia.com/badge?p=pdfobject)](https://packagephobia.com/result?p=pdfobject)
+[![npm](https://img.shields.io/npm/v/pdfobject.svg?style=flat)](https://www.npmjs.org/package/pdfobject) [![CDNJS](https://img.shields.io/cdnjs/v/pdfobject.svg)](https://cdnjs.com/libraries/pdfobject/) [![downloads](https://img.shields.io/npm/dm/pdfobject.svg)](https://www.npmjs.org/package/pdfobject) [![minzipped size](https://img.shields.io/bundlephobia/minzip/pdfobject.svg)](https://bundlephobia.com/package/pdfobject) [![install size](https://packagephobia.com/badge?p=pdfobject)](https://packagephobia.com/result?p=pdfobject)
 
 A lightweight JavaScript utility for dynamically embedding PDFs in HTML documents.
 


### PR DESCRIPTION
Adds some more useful badges:

- npm download count
- bundled and minified size
- npm package size

Also I moved them below the title which is what most projects do.

<img width="805" alt="image" src="https://github.com/pipwerks/PDFObject/assets/115237/6f6e8130-121d-4e0c-800f-bfa98ad67b09">
